### PR TITLE
docs: add verified-by-homebridge badge and update userID example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # homebridge-tesy-heater-mqtt
 
+[![verified-by-homebridge](https://img.shields.io/badge/_-verified-blueviolet?color=%23491F59&style=flat&logoColor=%23FFFFFF&logo=homebridge)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 [![Test](https://github.com/svjakrm/homebridge-tesy-heater-mqtt/actions/workflows/test.yml/badge.svg)](https://github.com/svjakrm/homebridge-tesy-heater-mqtt/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/svjakrm/homebridge-tesy-heater-mqtt/branch/main/graph/badge.svg)](https://codecov.io/gh/svjakrm/homebridge-tesy-heater-mqtt)
 [![npm version](https://badge.fury.io/js/homebridge-tesy-heater-mqtt.svg)](https://badge.fury.io/js/homebridge-tesy-heater-mqtt)

--- a/config.schema.json
+++ b/config.schema.json
@@ -68,7 +68,7 @@
         {
           "key": "userid",
           "type": "string",
-          "placeholder": "27356"
+          "placeholder": "11222"
         },
         {
           "key": "username",
@@ -104,7 +104,7 @@
     },
     {
       "type": "help",
-      "helpvalue": "<p><strong>How to find your User ID:</strong></p><ol><li>Log in to <a href='https://v4.mytesy.com' target='_blank'>Tesy Cloud</a> in your browser</li><li>Open Developer Tools (<kbd>F12</kbd> or right-click → Inspect)</li><li>Go to the <strong>Network</strong> tab and refresh the page</li><li>Find request named <code>get-my-devices</code> or <code>get-my-messages</code></li><li>Click on it and look for <code>userID</code> parameter in the request URL or Payload tab</li><li>Example: <code>userID=27356</code> - your User ID is <strong>27356</strong></li></ol>"
+      "helpvalue": "<p><strong>How to find your User ID:</strong></p><ol><li>Log in to <a href='https://v4.mytesy.com' target='_blank'>Tesy Cloud</a> in your browser</li><li>Open Developer Tools (<kbd>F12</kbd> or right-click → Inspect)</li><li>Go to the <strong>Network</strong> tab and refresh the page</li><li>Find request named <code>get-my-devices</code> or <code>get-my-messages</code></li><li>Click on it and look for <code>userID</code> parameter in the request URL or Payload tab</li><li>Example: <code>userID=11222</code> - your User ID is <strong>11222</strong></li></ol>"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- ✅ Add verified-by-homebridge badge to README (plugin passed official Homebridge verification!)
- 🔐 Update userID placeholder in config.schema.json for privacy (changed from 27356 to 11222)

## Details

The plugin has successfully passed Homebridge verification process. This PR adds the official verified badge to the README to showcase this achievement.

Also updated the example userID in config schema to use a generic placeholder instead of a potentially real user ID.

## Test plan

- [x] README badge displays correctly
- [x] Config schema validation still works
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)