### PR TITLE
feat: Add temperature correction support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration
+# Documentation: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%                    # Minimum coverage target for entire project
+        threshold: 1%                  # Acceptable coverage drop (1% won't fail)
+        if_ci_failed: error            # Show error if CI failed
+
+    patch:
+      default:
+        target: 70%                    # Coverage target for new changes (diff)
+        threshold: 2%                  # Acceptable threshold for patch
+        if_ci_failed: error
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default                   # Comment on every PR
+  require_changes: false              # Comment even if coverage unchanged
+  require_base: no                    # Don't require base commit for comparison
+  require_head: yes                   # Require head commit
+
+ignore:
+  - "test/**/*"                       # Ignore test files
+  - "**/*.test.js"                    # Ignore unit test files
+  - "test-*.js"                       # Ignore test scripts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # homebridge-tesy-heater-mqtt
 
+[![verified-by-homebridge](https://img.shields.io/badge/_-verified-blueviolet?color=%23491F59&style=flat&logoColor=%23FFFFFF&logo=homebridge)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 [![Test](https://github.com/svjakrm/homebridge-tesy-heater-mqtt/actions/workflows/test.yml/badge.svg)](https://github.com/svjakrm/homebridge-tesy-heater-mqtt/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/svjakrm/homebridge-tesy-heater-mqtt/branch/main/graph/badge.svg)](https://codecov.io/gh/svjakrm/homebridge-tesy-heater-mqtt)
 [![npm version](https://badge.fury.io/js/homebridge-tesy-heater-mqtt.svg)](https://badge.fury.io/js/homebridge-tesy-heater-mqtt)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This plugin allows you to control your Tesy smart heaters through Apple HomeKit 
 **Features:**
 - **Automatic device discovery** - finds all Tesy heaters in your account
 - **Multi-device support** - manages multiple heaters with one configuration
+- **Temperature sensor correction** - automatic calibration with power loss recovery
 - Turn heater on/off
 - Set target temperature
 - View current temperature
@@ -99,6 +100,27 @@ Add this platform to your Homebridge `config.json`:
 | `maxTemp` | No | Maximum temperature (°C) | `30` |
 | `minTemp` | No | Minimum temperature (°C) | `10` |
 | `pullInterval` | No | Status update interval (ms) | `60000` |
+| `tempCorrection` | No | Temperature sensor correction (°C, -4 to +4) | `0` |
+
+### Temperature Correction
+
+The plugin supports automatic temperature sensor correction (calibration). This is useful when your device's temperature sensor reads consistently higher or lower than the actual room temperature.
+
+**How it works:**
+- Configure the correction offset in °C (integer from -4 to +4)
+- Plugin automatically applies correction when device is discovered
+- Plugin monitors device and restores correction after power loss
+- Correction is checked every status update interval (default: 60 seconds)
+
+**Example:**
+If your heater shows 22°C but actual room temperature is 20°C, add this to your config:
+```json
+"tempCorrection": -2
+```
+
+The device will adjust its readings by -2°C internally.
+
+**Note:** Leave at `0` (default) or omit the field if your sensor is accurate. Valid range is -4 to +4 (integers only).
 
 ### How to Get Configuration Values
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,6 +49,14 @@
         "minimum": 30000,
         "maximum": 300000,
         "description": "How often to poll device status (in milliseconds). Default: 60000 (1 minute)"
+      },
+      "tempCorrection": {
+        "title": "Temperature Correction (°C)",
+        "type": "integer",
+        "default": 0,
+        "minimum": -4,
+        "maximum": 4,
+        "description": "Temperature sensor correction offset in °C (integer from -4 to +4). Automatically restored after power loss."
       }
     },
     "required": ["name", "userid", "username", "password"]
@@ -98,6 +106,10 @@
         },
         {
           "key": "pullInterval",
+          "type": "number"
+        },
+        {
+          "key": "tempCorrection",
           "type": "number"
         }
       ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -68,7 +68,7 @@
         {
           "key": "userid",
           "type": "string",
-          "placeholder": "27356"
+          "placeholder": "11222"
         },
         {
           "key": "username",
@@ -104,7 +104,7 @@
     },
     {
       "type": "help",
-      "helpvalue": "<p><strong>How to find your User ID:</strong></p><ol><li>Log in to <a href='https://v4.mytesy.com' target='_blank'>Tesy Cloud</a> in your browser</li><li>Open Developer Tools (<kbd>F12</kbd> or right-click → Inspect)</li><li>Go to the <strong>Network</strong> tab and refresh the page</li><li>Find request named <code>get-my-devices</code> or <code>get-my-messages</code></li><li>Click on it and look for <code>userID</code> parameter in the request URL or Payload tab</li><li>Example: <code>userID=27356</code> - your User ID is <strong>27356</strong></li></ol>"
+      "helpvalue": "<p><strong>How to find your User ID:</strong></p><ol><li>Log in to <a href='https://v4.mytesy.com' target='_blank'>Tesy Cloud</a> in your browser</li><li>Open Developer Tools (<kbd>F12</kbd> or right-click → Inspect)</li><li>Go to the <strong>Network</strong> tab and refresh the page</li><li>Find request named <code>get-my-devices</code> or <code>get-my-messages</code></li><li>Click on it and look for <code>userID</code> parameter in the request URL or Payload tab</li><li>Example: <code>userID=11222</code> - your User ID is <strong>11222</strong></li></ol>"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add automatic temperature correction (sensor calibration) with power loss recovery.

This feature allows users to configure a temperature correction offset that is automatically applied to the device and restored after power loss.

## Changes

### Configuration
- Add `tempCorrection` parameter to config.schema.json (range: -4 to +4°C, integers only)
- Add configuration validation and initialization in platform constructor

### MQTT Implementation
- Add `setTempCorrection()` method using discovered MQTT protocol:
  - Command: `setTCorrection`
  - Payload field: `"temp"` (as string, not number!)
  - API state field: `TCorrection` (integer)

### Sync Logic
- Initial correction applied on device discovery (2-second delay)
- Periodic sync during status updates (every pullInterval)
- Auto-restore after device power loss

### Testing
- Add 10 new unit tests for temperature correction
- Total: 78 tests passing (was 68)
- Coverage maintained at ~66%

### Documentation
- Update README.md with Temperature Correction section
- Update CLAUDE.md Version History (v1.0.6)
- Document MQTT protocol details

## MQTT Protocol Discovery

Research was conducted to identify the exact MQTT command format:
- **Command**: `setTCorrection` (not setTempCorrection)
- **Payload**: `{"app_id": "...", "temp": "3"}` ← value as **string**!
- **API State**: `TCorrection` (integer value)

## Test Plan

- [x] All existing tests pass (no regression)
- [x] 10 new unit tests for correction logic
- [x] Configuration validation tested
- [x] MQTT command payload tested (string conversion)
- [x] Sync logic tested (different scenarios)
- [ ] Manual testing pending (will test after merge)

## Verification

Resolves the issue of temperature correction resetting to 0 after device power loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)